### PR TITLE
Run tls as added if possible

### DIFF
--- a/Source/ArtilleryRuntime/Public/Systems/FArtilleryTicklitesThread.h
+++ b/Source/ArtilleryRuntime/Public/Systems/FArtilleryTicklitesThread.h
@@ -64,32 +64,32 @@ class FArtilleryTicklitesWorker : public FRunnable {
 	protected:
 	TickliteBuffer QueuedAdds;
 	
-	bool TickliteAdd(TSharedPtr<TicklitePrototype> AllocatedTL,  TicklitePhase Group)
+	TSharedPtr<TicklitePrototype> TickliteAdd(TSharedPtr<TicklitePrototype> AllocatedTL,  TicklitePhase Group)
 	{
 		switch (Group)
 		{
 		case TicklitePhase::Early :
 			{
 				ExecutionGroups[0].Add(AllocatedTL);
-				return true;
+				return AllocatedTL;
 			}
 		case TicklitePhase::Normal :
 			{
 				ExecutionGroups[1].Add( AllocatedTL);
-				return true;
+				return AllocatedTL;
 			}
 		case TicklitePhase::Late :
 			{
 				ExecutionGroups[2].Add(AllocatedTL);
-				return true;
+				return AllocatedTL;
 			}
 		case TicklitePhase::FINAL_TICK_RESOLVE :
 			{
 				ExecutionGroups[3].Add(AllocatedTL);
-				return true;
+				return AllocatedTL;
 			}	
 		}
-		return false;
+		return nullptr;
 	}
 	//we may be able to remove sim or move it outside the run loop. I don't think there's anything wrong with simulating
 	//as fast as we can, and it buys us a lot of perf time by not sleeping the thread until it's apply time.
@@ -198,6 +198,19 @@ class FArtilleryTicklitesWorker : public FRunnable {
 			StartTicklitesApply->Wait();
 			StartTicklitesApply->Reset(); // we can run long on sim, not on apply.
 
+			//if we have any ticklite requests, perform their calculations here and then
+			//add them.
+			while(!QueuedAdds->IsEmpty())
+			{
+				const StampLiteRequest AddTup = *QueuedAdds->Peek();
+				auto ptr =  TickliteAdd(AddTup.Key, AddTup.Value);
+				if(ptr)
+				{
+					CalcINE(ptr);
+				}
+				QueuedAdds->Dequeue();
+			}
+			
 			for (auto& Group : ExecutionGroups)
 			{
 				for(auto Tickable : Group)
@@ -206,12 +219,7 @@ class FArtilleryTicklitesWorker : public FRunnable {
 				}
 			}
 
-			while(!QueuedAdds->IsEmpty())
-			{
-				const StampLiteRequest AddTup = *QueuedAdds->Peek();
-				TickliteAdd(AddTup.Key, AddTup.Value);
-				QueuedAdds->Dequeue();
-			}
+
 				
 		}
 	

--- a/Source/ArtilleryRuntime/Public/Systems/FArtilleryTicklitesThread.h
+++ b/Source/ArtilleryRuntime/Public/Systems/FArtilleryTicklitesThread.h
@@ -200,6 +200,10 @@ class FArtilleryTicklitesWorker : public FRunnable {
 
 			//if we have any ticklite requests, perform their calculations here and then
 			//add them.
+			//TODO: Reassess 12/10/24
+			//this may cause consistency issues during resim, as artillery guns are fired on the main thread
+			//which is not cadence-locked to the artillery threads. however, during resim, I believe this can be
+			//resolved with the ticklite's add timestamp. and until we have resim, this is a non-issue.
 			while(!QueuedAdds->IsEmpty())
 			{
 				const StampLiteRequest AddTup = *QueuedAdds->Peek();


### PR DESCRIPTION
We will need to reassess the viability of this once resim is added. Unfortunately, ArtilleryGuns are fired on the main thread, which does not share a cadence with the tick system. this is proving to have a LOT of disadvantages, because the main thread is quite slow, but right now, we're sort of married to it because of blueprint and quite a few other reasons. I'll keep thinking about the problem and keep talking to folks about it.